### PR TITLE
Return FormItParameters as array for Fenom usage

### DIFF
--- a/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
+++ b/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
@@ -241,7 +241,8 @@ class FormaliciousSnippetRenderForm extends FormaliciousSnippets
                 }
 
                 return $this->getChunk($this->getProperty('tplForm'), array_merge($placeholders, $parameters, [
-                    'FormItParameters' => $this->parseParameters($parameters)
+                    'FormItParameters'      => $this->parseParameters($parameters),
+                    'FormItParametersArray' => $parameters
                 ]));
             }
         }


### PR DESCRIPTION
This sets the FormItParametersArray parameter which sets the FormIt parameters as an array so it can be used with Fenom.

So afterwards you can do this:
```
{$_modx->runSnippet('FormIt', $_pls['FormItParametersArray'])}

{$_modx->getPlaceholder('formalicious.navigation')}
{$_modx->getPlaceholder('formalicious.form')}
```