### PR TITLE
Set properties so they use the hook config

### DIFF
--- a/core/components/formalicious/model/formalicious/snippets/formalicioussnippethookrenderform.class.php
+++ b/core/components/formalicious/model/formalicious/snippets/formalicioussnippethookrenderform.class.php
@@ -27,6 +27,8 @@ class FormaliciousSnippetHookRenderForm extends FormaliciousSnippets
      */
     public function run($hook, array $errors = [])
     {
+        $this->properties = array_merge($this->properties, $hook->config);
+        
         $formit =& $hook->formit;
         $values = $hook->getValues();
 


### PR DESCRIPTION
This ensures that it picks up the properties set in the initial formaliciousRenderForm snippet call:
```  
{$_modx->runSnippet('FormaliciousRenderForm', [
                        'form'                  => $form,
                        'usePdoTools'           => true,
                        'usePdoElementsPath'    => true,
                        'tplForm'               => '@FILE elements/chunks/formalicious/form.tpl',
                        'tplStep'               => '@FILE elements/chunks/formalicious/step.tpl',
                        'tplEmailFieldsItem'    => '@FILE elements/chunks/formalicious/email/item.tpl',
                        'tplEmailFieldsWrapper' => '@FILE elements/chunks/formalicious/email/wrapper.tpl',
                    ])}
```