### PR TITLE
Update formalicioussnippetrenderform.class.php

### DIFF
--- a/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
+++ b/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
@@ -71,6 +71,8 @@ class FormaliciousSnippetRenderForm extends FormaliciousSnippets
 
                 'formaliciousFormId'    => $form->get('id'),
                 'formaliciousStep'      => 1,
+                'usePdoTools'           => $this->getProperty('usePdoTools'),
+                'usePdoElementsPath'    => $this->getProperty('usePdoElementsPath')
             ];
 
             $placeholders = [


### PR DESCRIPTION
Update renderForm class so it reuses the settings set from the snippet properties
```
{$_modx->runSnippet('FormaliciousRenderForm', [
                        'form'                  => $form,
                        'usePdoTools'           => true,
                        'usePdoElementsPath'    => true,
                        'tplForm'               => '@FILE elements/chunks/formalicious/form.tpl',
                        'tplStep'               => '@FILE elements/chunks/formalicious/step.tpl',
                        'tplEmailFieldsItem'    => '@FILE elements/chunks/formalicious/email/item.tpl',
                        'tplEmailFieldsWrapper' => '@FILE elements/chunks/formalicious/email/wrapper.tpl',
                    ])}
```

**Linked PR:**
https://github.com/Sterc/Formalicious/pull/6