### PR TITLE
Fix: Prehooks Inclusion

### DIFF
--- a/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
+++ b/core/components/formalicious/model/formalicious/snippets/formalicioussnippetrenderform.class.php
@@ -130,6 +130,14 @@ class FormaliciousSnippetRenderForm extends FormaliciousSnippets
                     $currentStepIndex++;
                 }
 
+                $formPrehooks = explode(',', trim($form->get('prehooks')));
+                $formPrehooks = !empty($formPrehooks) ? array_map('trim', $formPrehooks) : $formPrehooks ;
+
+                $scriptPrehooks = explode(',', trim($this->getProperty('preHooks')));
+                $scriptPrehooks = !empty($scriptPrehooks) ? array_map('trim', $scriptPrehooks) : $scriptPrehooks ;
+
+                $prehooks = array_filter(array_merge($formPrehooks, $scriptPrehooks));
+
                 if ($form->get('posthooks')) {
                     $hooks = array_merge(
                         array_filter(explode(',', $this->getProperty('hooks'))),
@@ -208,7 +216,7 @@ class FormaliciousSnippetRenderForm extends FormaliciousSnippets
                 }
 
                 $parameters['hooks'] = $this->parseHooks($hooks);
-                $parameters['preHooks'] = $this->parseHooks($this->getProperty('preHooks'));
+                $parameters['preHooks'] = $this->parseHooks($prehooks);
                 $parameters['renderHooks'] = $this->parseHooks($this->getProperty('renderHooks'));
                 $parameters['validate'] = $this->parseValidation($validation);
 


### PR DESCRIPTION
In the Formalicious manager component, hooks added to a form's Advanced Settings Prehooks do not get added (only ones added via the FormaliciousRenderForm snippet call are). This change solves the issue by merging the two hook sources