### PR TITLE
fixes: copy steps are not working when a form is duplicated

### DIFF
--- a/core/components/formalicious/src/Formalicious/Model/mysql/FormaliciousFieldType.php
+++ b/core/components/formalicious/src/Formalicious/Model/mysql/FormaliciousFieldType.php
@@ -2,6 +2,7 @@
 namespace Sterc\Formalicious\Model\mysql;
 
 use xPDO\xPDO;
+use Sterc\Formalicious\Model\FormaliciousField;
 
 class FormaliciousFieldType extends \Sterc\Formalicious\Model\FormaliciousFieldType
 {
@@ -88,7 +89,7 @@ class FormaliciousFieldType extends \Sterc\Formalicious\Model\FormaliciousFieldT
         array (
             'Fields' => 
             array (
-                'class' => 'FormaliciousField',
+                'class' => FormaliciousField::class,
                 'local' => 'id',
                 'foreign' => 'type',
                 'cardinality' => 'many',

--- a/core/components/formalicious/src/Formalicious/Model/mysql/FormaliciousForm.php
+++ b/core/components/formalicious/src/Formalicious/Model/mysql/FormaliciousForm.php
@@ -2,6 +2,8 @@
 namespace Sterc\Formalicious\Model\mysql;
 
 use xPDO\xPDO;
+use Sterc\Formalicious\Model\FormaliciousStep;
+use Sterc\Formalicious\Model\FormaliciousCategory;
 
 class FormaliciousForm extends \Sterc\Formalicious\Model\FormaliciousForm
 {
@@ -254,7 +256,7 @@ class FormaliciousForm extends \Sterc\Formalicious\Model\FormaliciousForm
         array (
             'Steps' => 
             array (
-                'class' => 'FormaliciousStep',
+                'class' => FormaliciousStep::class,
                 'local' => 'id',
                 'foreign' => 'form_id',
                 'cardinality' => 'many',
@@ -265,7 +267,7 @@ class FormaliciousForm extends \Sterc\Formalicious\Model\FormaliciousForm
         array (
             'Category' => 
             array (
-                'class' => 'FormaliciousCategory',
+                'class' => FormaliciousCategory::class,
                 'local' => 'category_id',
                 'foreign' => 'id',
                 'cardinality' => 'one',


### PR DESCRIPTION
## Error log

```
(ERROR @ /core/vendor/xpdo/xpdo/src/xPDO/xPDO.php:667): Could not load class. FormaliciousStep from mysql.formaliciousstep
(ERROR @ /core/vendor/xpdo/xpdo/src/xPDO/xPDO.php:787) FormaliciousStep::loadCollection() is not a valid static method.
```

## Steps to reproduce

Copy a form and check the steps. There should be no duplicate steps.

## Environment

MODX 3.1.2
Formalicious 3.1.1-pl
PHP version: 8.3.25